### PR TITLE
Improve SettingDefinition admin usability

### DIFF
--- a/confetti/admin.py
+++ b/confetti/admin.py
@@ -4,7 +4,7 @@ import json
 
 from django import forms
 from django.contrib import admin, messages
-from django.db.models import QuerySet
+from django.db.models import Count, QuerySet
 
 from .api import _ck  # внутренний хелпер для кэш-ключей
 from .models import (
@@ -176,18 +176,65 @@ class SettingCategoryAdmin(admin.ModelAdmin):
 @admin.register(SettingDefinition)
 class SettingDefinitionAdmin(admin.ModelAdmin):
     form = SettingDefinitionAdminForm
-    list_display = ("key", "category", "type", "enabled", "editable")
-    list_filter = ("category", "type", "enabled", "editable")
-    search_fields = ("key", "title", "description")
-    ordering = ("key",)
+    list_display = (
+        "key",
+        "title",
+        "category",
+        "type",
+        "required",
+        "enabled",
+        "editable",
+        "frontend",
+        "values_count",
+        "short_description",
+    )
+    list_filter = (
+        "category",
+        "type",
+        "required",
+        "enabled",
+        "editable",
+        "frontend",
+        ("description", admin.EmptyFieldListFilter),
+    )
+    search_fields = ("key", "title", "description", "category__code", "category__title")
+    ordering = ("category__code", "key")
+    list_select_related = ("category",)
+    list_display_links = ("key", "title")
+    list_per_page = 50
     inlines = [SettingValueInline]
     actions = [clear_cache_for_definitions, create_settings_snapshot]
     autocomplete_fields = ()  # на будущее
-    readonly_fields = ()
+    readonly_fields = ("values_count",)
+    fieldsets = (
+        ("Идентификация", {
+            "fields": ("key", "title", "description", "category"),
+        }),
+        ("Тип и значения", {
+            "fields": ("type", "default", "choices", "required"),
+        }),
+        ("Управление доступностью", {
+            "fields": ("enabled", "editable", "frontend"),
+        }),
+        ("Статистика", {
+            "fields": ("values_count",),
+        }),
+    )
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.select_related("category")
+        return qs.select_related("category").annotate(_values_count=Count("values"))
+
+    @admin.display(description="Значений", ordering="_values_count")
+    def values_count(self, obj: SettingDefinition):
+        return getattr(obj, "_values_count", 0)
+
+    @admin.display(description="Описание")
+    def short_description(self, obj: SettingDefinition):
+        if not obj.description:
+            return "—"
+        text = obj.description.strip()
+        return text if len(text) <= 120 else text[:117] + "…"
 
 
 @admin.register(SettingValue)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,46 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from confetti.admin import SettingDefinitionAdmin
+from confetti.models import SettingCategory, SettingDefinition, SettingType
+
+
+@pytest.mark.django_db
+def test_setting_definition_admin_annotates_values_count():
+    category, _ = SettingCategory.objects.get_or_create(code="ui", defaults={"title": "UI"})
+    definition = SettingDefinition.objects.create(
+        key="ui.theme.admin_test",
+        category=category,
+        type=SettingType.STR,
+        title="Theme",
+        description="Color theme for the UI",
+    )
+
+    admin_obj = SettingDefinitionAdmin(SettingDefinition, AdminSite())
+    request = RequestFactory().get("/admin/confetti/settingdefinition/")
+
+    db_definition = admin_obj.get_queryset(request).get(pk=definition.pk)
+
+    assert admin_obj.values_count(db_definition) == 0
+    assert admin_obj.short_description(db_definition) == "Color theme for the UI"
+
+
+@pytest.mark.django_db
+def test_setting_definition_admin_short_description_truncates():
+    category, _ = SettingCategory.objects.get_or_create(code="scheduler", defaults={"title": "Scheduler"})
+    description = "x" * 150
+    definition = SettingDefinition.objects.create(
+        key="scheduler.long",
+        category=category,
+        type=SettingType.STR,
+        title="Long description",
+        description=description,
+    )
+
+    admin_obj = SettingDefinitionAdmin(SettingDefinition, AdminSite())
+
+    short = admin_obj.short_description(definition)
+
+    assert len(short) == 118
+    assert short.endswith("…")


### PR DESCRIPTION
### Motivation
- Текущая админка для `SettingDefinition` неудобна для обзора большого реестра настроек и не показывает количество значений и краткое описание прямо в таблице. 
- Нужен удобный поиск/фильтрация и логичное групирование полей формы для более быстрой работы с настройками.

### Description
- Расширен `SettingDefinitionAdmin`: добавлены колонки `title`, `required`, `frontend`, `values_count` и `short_description`, а также улучшены `list_filter`, `search_fields`, `ordering`, `list_select_related` и `list_per_page` для удобного поиска и фильтрации. (`confetti/admin.py`)
- В `get_queryset` добавлена аннотация `Count('values')`, реализовано поле-ридонли `values_count` и метод `short_description`, который делает превью описания с усечением до 120 символов. (`confetti/admin.py`)
- Сформированы понятные `fieldsets` для формы редактирования настроек и помечено `values_count` как `readonly`. (`confetti/admin.py`)
- Добавлены автоматизированные тесты для проверки аннотации количества значений и корректного усечения описания в `tests/test_admin.py`.

### Testing
- Запущен тест `pytest -q tests/test_admin.py` и он прошел успешно. 
- Тронутые файлы проверены: `confetti/admin.py` и новый `tests/test_admin.py`, все тесты по админке зелёные.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36e441bc88327841a0eac76d3bd3d)