### PR TITLE
Sync boolean setting default with enabled toggle

### DIFF
--- a/confetti/models.py
+++ b/confetti/models.py
@@ -78,6 +78,21 @@ class SettingDefinition(models.Model):
     class Meta:
         ordering = ['key']
 
+    def save(self, *args, **kwargs):
+        if self.type == SettingType.BOOL:
+            should_sync_default = self.pk is None
+            if self.pk is not None:
+                previous_enabled = (
+                    SettingDefinition.objects
+                    .filter(pk=self.pk)
+                    .values_list('enabled', flat=True)
+                    .first()
+                )
+                should_sync_default = previous_enabled != self.enabled
+            if should_sync_default:
+                self.default = self.enabled
+        super().save(*args, **kwargs)
+
     def __str__(self):
         return self.key
 

--- a/tests/test_boolean_default_sync.py
+++ b/tests/test_boolean_default_sync.py
@@ -1,0 +1,45 @@
+import pytest
+
+from confetti.models import SettingCategory, SettingDefinition, SettingType
+
+
+@pytest.mark.django_db
+def test_bool_definition_syncs_default_on_create_from_enabled():
+    category, _ = SettingCategory.objects.get_or_create(code="flags", defaults={"title": "Flags"})
+
+    definition = SettingDefinition.objects.create(
+        key="feature.create-sync",
+        category=category,
+        type=SettingType.BOOL,
+        title="Create sync",
+        enabled=False,
+        default=True,
+    )
+
+    assert definition.default is False
+
+
+@pytest.mark.django_db
+def test_bool_definition_syncs_default_when_enabled_toggles():
+    category, _ = SettingCategory.objects.get_or_create(code="flags", defaults={"title": "Flags"})
+    definition = SettingDefinition.objects.create(
+        key="feature.toggle-sync",
+        category=category,
+        type=SettingType.BOOL,
+        title="Toggle sync",
+        enabled=True,
+        default=True,
+    )
+    assert definition.default is True
+
+    definition.enabled = False
+    definition.save()
+    definition.refresh_from_db()
+
+    assert definition.default is False
+
+    definition.enabled = True
+    definition.save()
+    definition.refresh_from_db()
+
+    assert definition.default is True


### PR DESCRIPTION
### Motivation
- Ensure boolean settings (`type == SettingType.BOOL`) have `default` that reflects the `enabled` state so frontends and API consumers see a consistent initial value.

### Description
- Added `SettingDefinition.save()` logic to automatically set `default` to the current `enabled` value when the definition is created or when `enabled` changes for boolean definitions.
- The implementation detects creation (`self.pk is None`) and compares the previous `enabled` value on updates to decide whether to synchronize `default`.
- Changes were made in `confetti/models.py` and a new test module `tests/test_boolean_default_sync.py` was added to cover creation and toggle scenarios.

### Testing
- Ran `pytest -q tests/test_boolean_default_sync.py tests/test_admin.py` and the tests completed successfully (all tests passed with only a PytestConfigWarning unrelated to the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d374630ff88327b4c38e9b156f6690)