### PR TITLE
Add full snapshot vs current settings comparison in Django admin

### DIFF
--- a/confetti/admin.py
+++ b/confetti/admin.py
@@ -5,6 +5,7 @@ import json
 from django import forms
 from django.contrib import admin, messages
 from django.db.models import Count, QuerySet
+from django.utils.html import escape, format_html
 
 from .api import _ck  # внутренний хелпер для кэш-ключей
 from .models import (
@@ -266,8 +267,8 @@ class SettingsSnapshotAdmin(admin.ModelAdmin):
     form = SettingsSnapshotAdminForm
     list_display = ("id", "created_at", "comment", "settings_count")
     search_fields = ("comment",)
-    readonly_fields = ("created_at", "settings_count", "pretty_payload")
-    fields = ("created_at", "comment", "settings_count", "pretty_payload", "payload")
+    readonly_fields = ("created_at", "settings_count", "comparison_report", "pretty_payload")
+    fields = ("created_at", "comment", "settings_count", "comparison_report", "pretty_payload", "payload")
     actions = [restore_settings_snapshot]
     ordering = ("-created_at", "-id")
 
@@ -278,3 +279,72 @@ class SettingsSnapshotAdmin(admin.ModelAdmin):
     @admin.display(description="Содержимое снимка")
     def pretty_payload(self, obj: SettingsSnapshot):
         return json.dumps(obj.payload, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def _build_snapshot_diff(
+        snapshot_payload: list[dict],
+        current_payload: list[dict],
+    ) -> dict:
+        snapshot_by_key = {item["key"]: item for item in snapshot_payload if item.get("key")}
+        current_by_key = {item["key"]: item for item in current_payload if item.get("key")}
+
+        snapshot_keys = set(snapshot_by_key)
+        current_keys = set(current_by_key)
+
+        only_in_snapshot = sorted(snapshot_keys - current_keys)
+        only_in_current = sorted(current_keys - snapshot_keys)
+        shared_keys = sorted(snapshot_keys & current_keys)
+
+        changed: list[dict] = []
+        unchanged_keys: list[str] = []
+
+        for key in shared_keys:
+            snapshot_item = snapshot_by_key[key]
+            current_item = current_by_key[key]
+            different_fields = sorted(
+                field_name
+                for field_name in (set(snapshot_item.keys()) | set(current_item.keys()))
+                if snapshot_item.get(field_name) != current_item.get(field_name)
+            )
+            if different_fields:
+                changed.append(
+                    {
+                        "key": key,
+                        "different_fields": different_fields,
+                        "snapshot": snapshot_item,
+                        "current": current_item,
+                    }
+                )
+            else:
+                unchanged_keys.append(key)
+
+        return {
+            "counts": {
+                "snapshot_total": len(snapshot_payload),
+                "current_total": len(current_payload),
+                "only_in_snapshot": len(only_in_snapshot),
+                "only_in_current": len(only_in_current),
+                "changed": len(changed),
+                "unchanged": len(unchanged_keys),
+            },
+            "only_in_snapshot": [
+                {"key": key, "snapshot": snapshot_by_key[key]}
+                for key in only_in_snapshot
+            ],
+            "only_in_current": [
+                {"key": key, "current": current_by_key[key]}
+                for key in only_in_current
+            ],
+            "changed": changed,
+            "unchanged_keys": unchanged_keys,
+        }
+
+    @admin.display(description="Сравнение с текущими настройками")
+    def comparison_report(self, obj: SettingsSnapshot):
+        if obj.pk is None:
+            return "Сохраните снимок, чтобы увидеть сравнение."
+
+        current_payload = build_global_settings_snapshot_payload()
+        diff = self._build_snapshot_diff(obj.payload or [], current_payload)
+        rendered = escape(json.dumps(diff, ensure_ascii=False, indent=2))
+        return format_html("<pre>{}</pre>", rendered)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,8 +2,15 @@ import pytest
 from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory
 
-from confetti.admin import SettingDefinitionAdmin
-from confetti.models import SettingCategory, SettingDefinition, SettingType
+from confetti.admin import SettingDefinitionAdmin, SettingsSnapshotAdmin
+from confetti.models import (
+    SettingCategory,
+    SettingDefinition,
+    SettingScope,
+    SettingsSnapshot,
+    SettingType,
+    SettingValue,
+)
 
 
 @pytest.mark.django_db
@@ -44,3 +51,76 @@ def test_setting_definition_admin_short_description_truncates():
 
     assert len(short) == 118
     assert short.endswith("…")
+
+
+def test_settings_snapshot_admin_build_snapshot_diff_detects_full_delta():
+    snapshot_payload = [
+        {"key": "a", "type": "str", "global_value": "old"},
+        {"key": "b", "type": "int", "global_value": 1},
+    ]
+    current_payload = [
+        {"key": "a", "type": "str", "global_value": "new"},
+        {"key": "c", "type": "bool", "global_value": True},
+    ]
+
+    diff = SettingsSnapshotAdmin._build_snapshot_diff(snapshot_payload, current_payload)
+
+    assert diff["counts"] == {
+        "snapshot_total": 2,
+        "current_total": 2,
+        "only_in_snapshot": 1,
+        "only_in_current": 1,
+        "changed": 1,
+        "unchanged": 0,
+    }
+    assert diff["only_in_snapshot"] == [{"key": "b", "snapshot": snapshot_payload[1]}]
+    assert diff["only_in_current"] == [{"key": "c", "current": current_payload[1]}]
+    assert diff["changed"][0]["key"] == "a"
+    assert diff["changed"][0]["different_fields"] == ["global_value"]
+    assert diff["changed"][0]["snapshot"] == snapshot_payload[0]
+    assert diff["changed"][0]["current"] == current_payload[0]
+    assert diff["unchanged_keys"] == []
+
+
+@pytest.mark.django_db
+def test_settings_snapshot_admin_comparison_report_contains_snapshot_and_current_states():
+    category, _ = SettingCategory.objects.get_or_create(code="ui", defaults={"title": "UI"})
+    definition = SettingDefinition.objects.create(
+        key="ui.theme.snapshot_admin",
+        category=category,
+        type=SettingType.STR,
+        title="Theme",
+    )
+    SettingValue.objects.create(
+        definition=definition,
+        scope=SettingScope.GLOBAL,
+        user=None,
+        value="light",
+    )
+
+    snapshot_payload = [{
+        "key": "ui.theme.snapshot_admin",
+        "type": "str",
+        "title": "Theme",
+        "description": "",
+        "default": [],
+        "choices": [],
+        "required": False,
+        "enabled": True,
+        "editable": True,
+        "frontend": False,
+        "category": {"code": "ui", "title": "UI"},
+        "has_global_value": True,
+        "global_value": "dark",
+    }]
+    snapshot = type("SnapshotObj", (), {"pk": 1, "payload": snapshot_payload})()
+    admin_obj = SettingsSnapshotAdmin(SettingsSnapshot, AdminSite())
+
+    rendered = str(admin_obj.comparison_report(snapshot))
+
+    assert "&quot;snapshot&quot;" in rendered
+    assert "&quot;current&quot;" in rendered
+    assert "&quot;only_in_snapshot&quot;" in rendered
+    assert "&quot;only_in_current&quot;" in rendered
+    assert "dark" in rendered
+    assert "light" in rendered


### PR DESCRIPTION
### Motivation
- Provide an easy way in the admin to compare a stored `SettingsSnapshot.payload` with the current global settings state so operators can inspect what changed between a snapshot and the live configuration.

### Description
- Added a read-only `comparison_report` field to `SettingsSnapshotAdmin` and included it in the admin `fields` so the comparison appears on the snapshot detail page (`confetti/admin.py`).
- Implemented `_build_snapshot_diff(snapshot_payload, current_payload)` which produces a full diff with counts, lists of keys only in snapshot, only in current, changed items with `different_fields`, and `unchanged_keys` (`confetti/admin.py`).
- Render the diff as escaped JSON in a `<pre>` block using `format_html` and `escape`, and derive the live `current_payload` by calling `build_global_settings_snapshot_payload()` from services (`confetti/admin.py`).
- Added tests covering the diff logic and the admin rendering: `test_settings_snapshot_admin_build_snapshot_diff_detects_full_delta` and `test_settings_snapshot_admin_comparison_report_contains_snapshot_and_current_states` (`tests/test_admin.py`).

### Testing
- Ran `pytest -q tests/test_admin.py`, and the test suite passed successfully.
- Ran `pytest -q tests/test_snapshots.py`, and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37d1fae848327a2cac017d35ebe10)